### PR TITLE
feat: TaikoSpecId added

### DIFF
--- a/src/evm/alloy.rs
+++ b/src/evm/alloy.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use alloy_evm::{Database, Evm, EvmEnv, eth::EthEvmContext};
+use alloy_evm::{Database, Evm, EvmEnv};
 use alloy_primitives::hex;
 use reth::revm::{
     Context, ExecuteEvm, InspectEvm, Inspector,
@@ -11,45 +11,48 @@ use reth::revm::{
         BlockEnv, TxEnv,
         result::{EVMError, ExecutionResult, HaltReason, Output, ResultAndState, SuccessReason},
     },
-    primitives::{Address, Bytes, TxKind, U256, hardfork::SpecId},
+    primitives::{Address, Bytes, TxKind, U256},
 };
-use reth_revm::{handler::PrecompileProvider, interpreter::InterpreterResult};
+use reth_revm::{context::CfgEnv, handler::PrecompileProvider, interpreter::InterpreterResult};
 use tracing::debug;
 
-use crate::evm::{evm::TaikoEvm, handler::get_treasury_address};
+use crate::{
+    evm::{evm::TaikoEvm, handler::get_treasury_address},
+    revm::spec::TaikoSpecId,
+};
 
 pub const TAIKO_GOLDEN_TOUCH_ADDRESS: [u8; 20] = hex!("0x0000777735367b36bc9b61c50022d9d0700db4ec");
 
 /// A wrapper around the Taiko EVM that implements the `Evm` trait in `alloy_evm`.
 pub struct TaikoEvmWrapper<DB: Database, INSP, P> {
-    inner: TaikoEvm<EthEvmContext<DB>, INSP, P>,
+    inner: TaikoEvm<TaikoEvmContext<DB>, INSP, P>,
     inspect: bool,
 }
 
 impl<DB: Database, INSP, P> TaikoEvmWrapper<DB, INSP, P> {
     /// Creates a new [`TaikoEvmWrapper`] instance.
-    pub const fn new(evm: TaikoEvm<EthEvmContext<DB>, INSP, P>, inspect: bool) -> Self {
+    pub const fn new(evm: TaikoEvm<TaikoEvmContext<DB>, INSP, P>, inspect: bool) -> Self {
         Self { inner: evm, inspect }
     }
 
     /// Consumes self and return the inner EVM instance.
-    pub fn into_inner(self) -> TaikoEvm<EthEvmContext<DB>, INSP, P> {
+    pub fn into_inner(self) -> TaikoEvm<TaikoEvmContext<DB>, INSP, P> {
         self.inner
     }
 
     /// Provides a reference to the EVM context.
-    pub const fn ctx(&self) -> &EthEvmContext<DB> {
+    pub const fn ctx(&self) -> &TaikoEvmContext<DB> {
         &self.inner.inner.ctx
     }
 
     /// Provides a mutable reference to the EVM context.
-    pub fn ctx_mut(&mut self) -> &mut EthEvmContext<DB> {
+    pub fn ctx_mut(&mut self) -> &mut TaikoEvmContext<DB> {
         &mut self.inner.inner.ctx
     }
 }
 
 impl<DB: Database, I, P> Deref for TaikoEvmWrapper<DB, I, P> {
-    type Target = EthEvmContext<DB>;
+    type Target = TaikoEvmContext<DB>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -64,6 +67,8 @@ impl<DB: Database, I, P> DerefMut for TaikoEvmWrapper<DB, I, P> {
     }
 }
 
+pub type TaikoEvmContext<DB> = Context<BlockEnv, TxEnv, CfgEnv<TaikoSpecId>, DB>;
+
 /// An instance of an ethereum virtual machine.
 ///
 /// An EVM is commonly initialized with the corresponding block context and state and it's only
@@ -73,8 +78,8 @@ impl<DB: Database, I, P> DerefMut for TaikoEvmWrapper<DB, I, P> {
 impl<DB, I, P> Evm for TaikoEvmWrapper<DB, I, P>
 where
     DB: Database,
-    I: Inspector<EthEvmContext<DB>>,
-    P: PrecompileProvider<EthEvmContext<DB>, Output = InterpreterResult>,
+    I: Inspector<TaikoEvmContext<DB>>,
+    P: PrecompileProvider<TaikoEvmContext<DB>, Output = InterpreterResult>,
 {
     /// Database type held by the EVM.
     type DB = DB;
@@ -89,7 +94,7 @@ where
     type HaltReason = HaltReason;
     /// Identifier of the EVM specification. EVM is expected to use this identifier to determine
     /// which features are enabled.
-    type Spec = SpecId;
+    type Spec = TaikoSpecId;
     /// Precompiles used by the EVM.
     type Precompiles = P;
     /// Evm inspector.
@@ -128,8 +133,8 @@ where
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         // NOTE: we use this workaround to mark the Anchor transaction and base fee share percentage
         // in this block.
-        if caller == Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS)
-            && contract == get_treasury_address(self.chain_id())
+        if caller == Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS) &&
+            contract == get_treasury_address(self.chain_id())
         {
             let (base_fee_share_pctg, caller_nonce) = decode_anchor_system_call_data(&data)
                 .ok_or(EVMError::Custom("invalid encoded anchor system call data".to_string()))?;

--- a/src/evm/factory.rs
+++ b/src/evm/factory.rs
@@ -1,4 +1,4 @@
-use alloy_evm::{Database, EvmEnv, EvmFactory, eth::EthEvmContext};
+use alloy_evm::{Database, EvmEnv, EvmFactory};
 use reth::revm::{
     Context, Inspector, MainBuilder, MainContext,
     context::{
@@ -7,12 +7,17 @@ use reth::revm::{
     },
     inspector::NoOpInspector,
     interpreter::interpreter::EthInterpreter,
-    primitives::hardfork::SpecId,
 };
 use reth_evm::precompiles::PrecompilesMap;
 use reth_revm::precompile::{PrecompileSpecId, Precompiles};
 
-use crate::evm::{alloy::TaikoEvmWrapper, evm::TaikoEvm};
+use crate::{
+    evm::{
+        alloy::{TaikoEvmContext, TaikoEvmWrapper},
+        evm::TaikoEvm,
+    },
+    revm::spec::TaikoSpecId,
+};
 
 /// A factory type for creating instances of the Taiko EVM given a certain input.
 #[derive(Default, Debug, Clone, Copy)]
@@ -20,7 +25,7 @@ pub struct TaikoEvmFactory;
 
 impl EvmFactory for TaikoEvmFactory {
     /// The EVM type that this factory creates.
-    type Evm<DB: Database, I: Inspector<EthEvmContext<DB>, EthInterpreter>> =
+    type Evm<DB: Database, I: Inspector<TaikoEvmContext<DB>, EthInterpreter>> =
         TaikoEvmWrapper<DB, I, Self::Precompiles>;
     /// Transaction environment.
     type Tx = TxEnv;
@@ -29,9 +34,9 @@ impl EvmFactory for TaikoEvmFactory {
     /// Halt reason.
     type HaltReason = HaltReason;
     /// The EVM context for inspectors.
-    type Context<DB: Database> = EthEvmContext<DB>;
+    type Context<DB: Database> = TaikoEvmContext<DB>;
     /// The EVM specification identifier
-    type Spec = SpecId;
+    type Spec = TaikoSpecId;
     /// Precompiles used by the EVM.
     type Precompiles = PrecompilesMap;
 
@@ -48,7 +53,7 @@ impl EvmFactory for TaikoEvmFactory {
             .with_db(db)
             .build_mainnet_with_inspector(NoOpInspector {})
             .with_precompiles(PrecompilesMap::from_static(Precompiles::new(
-                PrecompileSpecId::from_spec_id(spec_id),
+                PrecompileSpecId::from_spec_id(spec_id.into()),
             )));
 
         TaikoEvmWrapper::new(TaikoEvm::new(evm), false)
@@ -68,7 +73,7 @@ impl EvmFactory for TaikoEvmFactory {
             .with_db(db)
             .build_mainnet_with_inspector(NoOpInspector {})
             .with_precompiles(PrecompilesMap::from_static(Precompiles::new(
-                PrecompileSpecId::from_spec_id(spec_id),
+                PrecompileSpecId::from_spec_id(spec_id.into()),
             )))
             .with_inspector(inspector);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod db;
 pub mod evm;
 pub mod network;
 pub mod payload;
+pub mod revm;
 pub mod rpc;
 
 use crate::{

--- a/src/revm/mod.rs
+++ b/src/revm/mod.rs
@@ -1,0 +1,1 @@
+pub mod spec;

--- a/src/revm/spec.rs
+++ b/src/revm/spec.rs
@@ -1,0 +1,116 @@
+use core::str::FromStr;
+use reth::revm::primitives::hardfork::{SpecId, UnknownHardfork};
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[allow(non_camel_case_types)]
+pub enum TaikoSpecId {
+    /// Ontake hard fork for the Taiko network
+    ONTAKE,
+    /// Pacaya hard fork for the Taiko network
+    #[default]
+    PACAYA,
+    /// Shasta hard fork for the Taiko network
+    SHASTA,
+}
+
+impl TaikoSpecId {
+    /// Converts the [`TaikoSpecId`] into a [`SpecId`].
+    pub const fn into_eth_spec(self) -> SpecId {
+        match self {
+            Self::ONTAKE | Self::PACAYA | Self::SHASTA => SpecId::SHANGHAI,
+        }
+    }
+
+    pub const fn is_enabled_in(self, other: TaikoSpecId) -> bool {
+        other as u8 <= self as u8
+    }
+}
+
+impl From<TaikoSpecId> for SpecId {
+    fn from(spec: TaikoSpecId) -> Self {
+        spec.into_eth_spec()
+    }
+}
+
+impl FromStr for TaikoSpecId {
+    type Err = UnknownHardfork;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            name::ONTAKE => Ok(TaikoSpecId::ONTAKE),
+            name::PACAYA => Ok(TaikoSpecId::PACAYA),
+            name::SHASTA => Ok(TaikoSpecId::SHASTA),
+            _ => Err(UnknownHardfork),
+        }
+    }
+}
+
+impl From<TaikoSpecId> for &'static str {
+    fn from(spec_id: TaikoSpecId) -> Self {
+        match spec_id {
+            TaikoSpecId::ONTAKE => name::ONTAKE,
+            TaikoSpecId::PACAYA => name::PACAYA,
+            TaikoSpecId::SHASTA => name::SHASTA,
+        }
+    }
+}
+
+/// String identifiers for Optimism hardforks
+pub mod name {
+    pub const ONTAKE: &str = "Ontake";
+    pub const PACAYA: &str = "Pacaya";
+    pub const SHASTA: &str = "Shasta";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::vec;
+
+    #[test]
+    fn test_taiko_spec_id_eth_spec_compatibility() {
+        // Define test cases: (OpSpecId, enabled in ETH specs, enabled in OP specs)
+        let test_cases = [(
+            TaikoSpecId::PACAYA,
+            vec![
+                (SpecId::MERGE, true),
+                (SpecId::SHANGHAI, true),
+                (SpecId::CANCUN, false),
+                (SpecId::default(), false),
+            ],
+            vec![
+                (TaikoSpecId::ONTAKE, true),
+                (TaikoSpecId::PACAYA, true),
+                (TaikoSpecId::SHASTA, false),
+            ],
+        )];
+
+        for (taiko_spec, eth_tests, taiko_tests) in test_cases {
+            // Test ETH spec compatibility
+            for (eth_spec, expected) in eth_tests {
+                assert_eq!(
+                    taiko_spec.into_eth_spec().is_enabled_in(eth_spec),
+                    expected,
+                    "{:?} should {} be enabled in ETH {:?}",
+                    taiko_spec,
+                    if expected { "" } else { "not " },
+                    eth_spec
+                );
+            }
+
+            // Test OP spec compatibility
+            for (other_taiko_spec, expected) in taiko_tests {
+                assert_eq!(
+                    taiko_spec.is_enabled_in(other_taiko_spec),
+                    expected,
+                    "{:?} should {} be enabled in TAIKO {:?}",
+                    taiko_spec,
+                    if expected { "" } else { "not " },
+                    other_taiko_spec
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
<h1> What's new </h1>

* `TaikoSpecId` structure added
* Default eth's `SpecId` replaced with `TaikoSpecId`
* Created folder revm 

`SpecId` originates from revm, not reth. So I thought it'd better to create separate revm folder for the future and don't mix them.
 